### PR TITLE
Fix format string  to correctly escape '%'

### DIFF
--- a/bin/export_overlays
+++ b/bin/export_overlays
@@ -96,7 +96,7 @@ foreach my $layer ( @layers ) {
 
     # Create tex for this layer
     printf TEXFILE "
-  \% Layer \"%s\"
+  %% Layer \"%s\"
   \\pgfdeclareimage[width=\\paperwidth]{%s}{%s}
   \\begin{textblock}{1}(0,0)
     \\pgfuseimage<%s>{%s}


### PR DESCRIPTION
A literal percent should be '%%' not '\\%'. While '\\% Layer' apparently worked with older versions of perl, the % now starts off a placeholder in the format string, with 'L' being a format modifier for '%a' (conversion to hexadecimal floating point) and the 'yer' pass through, hence the output '0x0p+0yer'

              %a    hexadecimal floating point

              q, L, or ll interpret integer as C type "long long",
                          "unsigned long long", or "quad" (typically
                          64-bit integers)

(from perlfunc(1))

Closes #3 